### PR TITLE
Set DefaultRetentionDays MinValue to 1 and Preserve Existing Log Group Retention

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -88,9 +88,10 @@ Parameters:
   # Lambda Configuration
   DefaultRetentionDays:
     Type: Number
+    Default: 1
     MinValue: 1
     MaxValue: 3653
-    Description: Default retention period for log groups in days
+    Description: Default retention period for log groups in days. Only log groups with no retention set will be remediated; any existing retention (1 day or more) is considered compliant and will be preserved.
 
   LambdaMemorySize:
     Type: Number


### PR DESCRIPTION
# Update DefaultRetentionDays Default Value

- Set the `Default` of `DefaultRetentionDays` parameter to `1`.  
- Ensures that CloudWatch log groups without a retention policy are remediated to retain logs for at least 1 day.  
- Preserves existing retention settings and complies with AWS CloudWatch minimum retention requirements.
