### PR TITLE
Add dry-run compliance service and related tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,60 @@
+# Multi-stage build for LogGuardian container
+# Stage 1: Build stage
+FROM golang:1.24-alpine AS builder
+
+# Install build dependencies
+RUN apk add --no-cache git ca-certificates tzdata
+
+# Set working directory
+WORKDIR /build
+
+# Copy go mod files
+COPY go.mod go.sum ./
+
+# Download dependencies
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Build the container binary
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+    go build -ldflags="-w -s -X main.version=$(cat VERSION 2>/dev/null || echo 'unknown')" \
+    -o logguardian-container \
+    cmd/container/main.go
+
+# Stage 2: Runtime stage
+FROM alpine:3.19
+
+# Install runtime dependencies
+RUN apk add --no-cache ca-certificates tzdata && \
+    adduser -D -u 1000 -g 1000 logguardian
+
+# Copy timezone data for proper timestamp handling
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+
+# Copy the binary from builder
+COPY --from=builder /build/logguardian-container /usr/local/bin/logguardian
+
+# Set proper permissions
+RUN chmod +x /usr/local/bin/logguardian
+
+# Switch to non-root user
+USER logguardian
+
+# Set environment variables for container operation
+ENV AWS_REGION=""
+ENV CONFIG_RULE_NAME=""
+ENV BATCH_SIZE="10"
+ENV DRY_RUN="false"
+ENV APP_VERSION="1.3.0"
+
+# Health check endpoint (container exits after execution, so this is mainly for build verification)
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=1 \
+    CMD /usr/local/bin/logguardian --help || exit 1
+
+# Set entrypoint
+ENTRYPOINT ["/usr/local/bin/logguardian"]
+
+# Default command (show help)
+CMD ["--help"]

--- a/Makefile
+++ b/Makefile
@@ -310,3 +310,93 @@ help:
 	@echo "  make deploy-prod # Deploy to production account"
 	@echo ""
 	@echo "For complete SAM targets, see: sam.mk"
+
+# =============================================================================
+# Container Build Targets
+# =============================================================================
+
+# Container variables
+CONTAINER_IMAGE := logguardian
+CONTAINER_TAG := $(VERSION)
+CONTAINER_REGISTRY := 
+CONTAINER_BINARY := logguardian-container
+
+# Build container binary
+.PHONY: container-build
+container-build:
+	@echo "Building container binary..."
+	mkdir -p $(BUILD_DIR)
+	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build \
+		-ldflags="-s -w -X main.version=$(VERSION)" \
+		-o $(BUILD_DIR)/$(CONTAINER_BINARY) \
+		./cmd/container
+
+# Build Docker image
+.PHONY: docker-build
+docker-build:
+	@echo "Building Docker image $(CONTAINER_IMAGE):$(CONTAINER_TAG)..."
+	docker build -t $(CONTAINER_IMAGE):$(CONTAINER_TAG) \
+		-t $(CONTAINER_IMAGE):latest \
+		--build-arg VERSION=$(VERSION) \
+		.
+
+# Run container locally with dry-run
+.PHONY: docker-run-dryrun
+docker-run-dryrun: docker-build
+	@echo "Running container in dry-run mode..."
+	docker run --rm \
+		-e AWS_REGION=us-east-1 \
+		-e CONFIG_RULE_NAME=test-rule \
+		-e DRY_RUN=true \
+		-v ~/.aws:/home/logguardian/.aws:ro \
+		$(CONTAINER_IMAGE):$(CONTAINER_TAG) \
+		--dry-run --verbose
+
+# Run container with AWS credentials
+.PHONY: docker-run
+docker-run: docker-build
+	@echo "Running container..."
+	docker run --rm \
+		-e AWS_REGION=$(AWS_REGION) \
+		-e CONFIG_RULE_NAME=$(CONFIG_RULE_NAME) \
+		-v ~/.aws:/home/logguardian/.aws:ro \
+		$(CONTAINER_IMAGE):$(CONTAINER_TAG)
+
+# Push container to registry
+.PHONY: docker-push
+docker-push:
+	@if [ -z "$(CONTAINER_REGISTRY)" ]; then \
+		echo "Error: CONTAINER_REGISTRY not set"; \
+		exit 1; \
+	fi
+	@echo "Tagging image for registry..."
+	docker tag $(CONTAINER_IMAGE):$(CONTAINER_TAG) $(CONTAINER_REGISTRY)/$(CONTAINER_IMAGE):$(CONTAINER_TAG)
+	docker tag $(CONTAINER_IMAGE):$(CONTAINER_TAG) $(CONTAINER_REGISTRY)/$(CONTAINER_IMAGE):latest
+	@echo "Pushing to registry..."
+	docker push $(CONTAINER_REGISTRY)/$(CONTAINER_IMAGE):$(CONTAINER_TAG)
+	docker push $(CONTAINER_REGISTRY)/$(CONTAINER_IMAGE):latest
+
+# Clean container artifacts
+.PHONY: docker-clean
+docker-clean:
+	@echo "Cleaning container images..."
+	docker rmi $(CONTAINER_IMAGE):$(CONTAINER_TAG) $(CONTAINER_IMAGE):latest 2>/dev/null || true
+	rm -f $(BUILD_DIR)/$(CONTAINER_BINARY)
+
+# Run container tests
+.PHONY: container-test
+container-test:
+	@echo "Running container tests..."
+	go test -v ./cmd/container/... ./internal/container/...
+
+# Validate container build
+.PHONY: container-validate
+container-validate: container-build container-test docker-build
+	@echo "Container validation complete"
+
+# Scan container for vulnerabilities
+.PHONY: docker-scan
+docker-scan: docker-build
+	@echo "Scanning container for vulnerabilities..."
+	@which trivy > /dev/null 2>&1 || (echo "Trivy not installed. Install from https://github.com/aquasecurity/trivy" && exit 1)
+	trivy image $(CONTAINER_IMAGE):$(CONTAINER_TAG)

--- a/cmd/container/main.go
+++ b/cmd/container/main.go
@@ -1,0 +1,254 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/zsoftly/logguardian/internal/container"
+)
+
+const (
+	ExitSuccess = 0
+	ExitError   = 1
+	ExitUsage   = 2
+)
+
+type CommandInput struct {
+	Type           string
+	ConfigRuleName string
+	Region         string
+	BatchSize      int
+	DryRun         bool
+	Profile        string
+	AssumeRole     string
+	Verbose        bool
+	OutputFormat   string
+}
+
+func main() {
+	input := parseCommandLineArgs()
+
+	logLevel := slog.LevelInfo
+	if input.Verbose {
+		logLevel = slog.LevelDebug
+	}
+
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: logLevel,
+	}))
+	slog.SetDefault(logger)
+
+	executionID := fmt.Sprintf("exec-%d", time.Now().Unix())
+	startTime := time.Now()
+	slog.Info("Starting LogGuardian container execution",
+		"execution_id", executionID,
+		"version", getVersion(),
+		"mode", getExecutionMode(input.DryRun))
+
+	ctx := context.Background()
+	exitCode := execute(ctx, input, executionID)
+
+	slog.Info("Execution completed",
+		"execution_id", executionID,
+		"exit_code", exitCode,
+		"duration", time.Since(startTime).String())
+
+	os.Exit(exitCode)
+}
+
+func parseCommandLineArgs() CommandInput {
+	input := CommandInput{}
+
+	flag.StringVar(&input.Type, "type", "config-rule-evaluation", "Request type: config-rule-evaluation")
+	flag.StringVar(&input.ConfigRuleName, "config-rule", "", "AWS Config rule name to evaluate")
+	flag.StringVar(&input.Region, "region", os.Getenv("AWS_REGION"), "AWS region")
+	flag.IntVar(&input.BatchSize, "batch-size", 10, "Batch size for processing resources")
+	flag.BoolVar(&input.DryRun, "dry-run", false, "Preview changes without applying them")
+	flag.StringVar(&input.Profile, "profile", os.Getenv("AWS_PROFILE"), "AWS profile to use")
+	flag.StringVar(&input.AssumeRole, "assume-role", os.Getenv("AWS_ASSUME_ROLE_ARN"), "IAM role ARN to assume")
+	flag.BoolVar(&input.Verbose, "verbose", false, "Enable verbose logging")
+	flag.StringVar(&input.OutputFormat, "output", "json", "Output format: json or text")
+
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: %s [options]\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "\nEvaluate and remediate AWS Config compliance for CloudWatch Log Groups.\n\n")
+		fmt.Fprintf(os.Stderr, "Options:\n")
+		flag.PrintDefaults()
+		fmt.Fprintf(os.Stderr, "\nEnvironment Variables:\n")
+		fmt.Fprintf(os.Stderr, "  AWS_REGION              Default AWS region\n")
+		fmt.Fprintf(os.Stderr, "  AWS_PROFILE             AWS profile to use\n")
+		fmt.Fprintf(os.Stderr, "  AWS_ASSUME_ROLE_ARN     IAM role ARN to assume\n")
+		fmt.Fprintf(os.Stderr, "  CONFIG_RULE_NAME        Config rule name (alternative to --config-rule)\n")
+		fmt.Fprintf(os.Stderr, "  BATCH_SIZE              Batch size for processing\n")
+		fmt.Fprintf(os.Stderr, "  DRY_RUN                 Set to 'true' for dry-run mode\n")
+	}
+
+	flag.Parse()
+
+	// Check environment variables as fallback
+	if input.ConfigRuleName == "" {
+		input.ConfigRuleName = os.Getenv("CONFIG_RULE_NAME")
+	}
+	if input.Region == "" {
+		input.Region = os.Getenv("AWS_DEFAULT_REGION")
+	}
+	if envBatchSize := os.Getenv("BATCH_SIZE"); envBatchSize != "" {
+		var batchSize int
+		fmt.Sscanf(envBatchSize, "%d", &batchSize)
+		if batchSize > 0 {
+			input.BatchSize = batchSize
+		}
+	}
+	if strings.ToLower(os.Getenv("DRY_RUN")) == "true" {
+		input.DryRun = true
+	}
+
+	return input
+}
+
+func execute(ctx context.Context, input CommandInput, executionID string) int {
+	if err := validateInput(input); err != nil {
+		slog.Error("Invalid input", "error", err, "execution_id", executionID)
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		flag.Usage()
+		return ExitUsage
+	}
+
+	// Create AWS config with authentication strategy
+	awsCfg, err := createAWSConfig(ctx, input)
+	if err != nil {
+		slog.Error("Failed to create AWS config", "error", err, "execution_id", executionID)
+		outputError(input.OutputFormat, executionID, "Authentication failed", err)
+		return ExitError
+	}
+
+	// Create the command processor
+	processor := container.NewCommandProcessor(awsCfg, container.ProcessorOptions{
+		DryRun:       input.DryRun,
+		ExecutionID:  executionID,
+		OutputFormat: input.OutputFormat,
+	})
+
+	// Execute the command
+	result, err := processor.Execute(ctx, container.CommandRequest{
+		Type:           input.Type,
+		ConfigRuleName: input.ConfigRuleName,
+		Region:         input.Region,
+		BatchSize:      input.BatchSize,
+	})
+
+	if err != nil {
+		slog.Error("Command execution failed", "error", err, "execution_id", executionID)
+		outputError(input.OutputFormat, executionID, "Execution failed", err)
+		return ExitError
+	}
+
+	// Output the result
+	if err := outputResult(input.OutputFormat, result); err != nil {
+		slog.Error("Failed to output result", "error", err, "execution_id", executionID)
+		return ExitError
+	}
+
+	return ExitSuccess
+}
+
+func validateInput(input CommandInput) error {
+	if input.Type != "config-rule-evaluation" {
+		return fmt.Errorf("unsupported request type: %s", input.Type)
+	}
+
+	if input.ConfigRuleName == "" {
+		return fmt.Errorf("config rule name is required (use --config-rule or CONFIG_RULE_NAME env var)")
+	}
+
+	if input.Region == "" {
+		return fmt.Errorf("region is required (use --region, AWS_REGION, or AWS_DEFAULT_REGION env var)")
+	}
+
+	if input.BatchSize <= 0 || input.BatchSize > 100 {
+		return fmt.Errorf("batch size must be between 1 and 100")
+	}
+
+	return nil
+}
+
+func createAWSConfig(ctx context.Context, input CommandInput) (aws.Config, error) {
+	authStrategy := container.NewAuthenticationStrategy()
+
+	options := container.AuthOptions{
+		Profile:    input.Profile,
+		AssumeRole: input.AssumeRole,
+		Region:     input.Region,
+	}
+
+	return authStrategy.GetAWSConfig(ctx, options)
+}
+
+func outputResult(format string, result *container.ExecutionResult) error {
+	switch format {
+	case "json":
+		encoder := json.NewEncoder(os.Stdout)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(result)
+	case "text":
+		fmt.Printf("Execution ID: %s\n", result.ExecutionID)
+		fmt.Printf("Status: %s\n", result.Status)
+		fmt.Printf("Mode: %s\n", result.Mode)
+		fmt.Printf("Config Rule: %s\n", result.ConfigRuleName)
+		fmt.Printf("Region: %s\n", result.Region)
+		fmt.Printf("Total Processed: %d\n", result.TotalProcessed)
+		fmt.Printf("Success Count: %d\n", result.SuccessCount)
+		fmt.Printf("Failure Count: %d\n", result.FailureCount)
+		fmt.Printf("Duration: %s\n", result.Duration)
+		if result.DryRunSummary != nil {
+			fmt.Printf("\nDry Run Summary:\n")
+			fmt.Printf("  Would Apply Encryption: %d\n", result.DryRunSummary.WouldApplyEncryption)
+			fmt.Printf("  Would Apply Retention: %d\n", result.DryRunSummary.WouldApplyRetention)
+			fmt.Printf("  Already Compliant: %d\n", result.DryRunSummary.AlreadyCompliant)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported output format: %s", format)
+	}
+}
+
+func outputError(format, executionID, message string, err error) {
+	result := &container.ExecutionResult{
+		ExecutionID: executionID,
+		Status:      "failed",
+		Error:       fmt.Sprintf("%s: %v", message, err),
+		Timestamp:   time.Now(),
+	}
+
+	switch format {
+	case "json":
+		encoder := json.NewEncoder(os.Stderr)
+		encoder.SetIndent("", "  ")
+		encoder.Encode(result)
+	case "text":
+		fmt.Fprintf(os.Stderr, "Execution ID: %s\n", executionID)
+		fmt.Fprintf(os.Stderr, "Status: failed\n")
+		fmt.Fprintf(os.Stderr, "Error: %s: %v\n", message, err)
+	}
+}
+
+func getVersion() string {
+	if version := os.Getenv("APP_VERSION"); version != "" {
+		return version
+	}
+	return "unknown"
+}
+
+func getExecutionMode(dryRun bool) string {
+	if dryRun {
+		return "dry-run"
+	}
+	return "apply"
+}

--- a/cmd/container/main_test.go
+++ b/cmd/container/main_test.go
@@ -1,0 +1,271 @@
+package main
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseCommandLineArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		envVars  map[string]string
+		expected CommandInput
+	}{
+		{
+			name: "default values",
+			args: []string{"cmd"},
+			expected: CommandInput{
+				Type:         "config-rule-evaluation",
+				BatchSize:    10,
+				OutputFormat: "json",
+			},
+		},
+		{
+			name: "with command line args",
+			args: []string{"cmd", "--config-rule", "test-rule", "--region", "us-west-2", "--batch-size", "20", "--dry-run"},
+			expected: CommandInput{
+				Type:           "config-rule-evaluation",
+				ConfigRuleName: "test-rule",
+				Region:         "us-west-2",
+				BatchSize:      20,
+				DryRun:         true,
+				OutputFormat:   "json",
+			},
+		},
+		{
+			name: "with environment variables",
+			args: []string{"cmd"},
+			envVars: map[string]string{
+				"CONFIG_RULE_NAME": "env-rule",
+				"AWS_REGION":       "eu-west-1",
+				"BATCH_SIZE":       "30",
+				"DRY_RUN":          "true",
+			},
+			expected: CommandInput{
+				Type:           "config-rule-evaluation",
+				ConfigRuleName: "env-rule",
+				Region:         "eu-west-1",
+				BatchSize:      30,
+				DryRun:         true,
+				OutputFormat:   "json",
+			},
+		},
+		{
+			name: "command line overrides environment",
+			args: []string{"cmd", "--config-rule", "cli-rule", "--region", "ap-south-1"},
+			envVars: map[string]string{
+				"CONFIG_RULE_NAME": "env-rule",
+				"AWS_REGION":       "eu-west-1",
+			},
+			expected: CommandInput{
+				Type:           "config-rule-evaluation",
+				ConfigRuleName: "cli-rule",
+				Region:         "ap-south-1",
+				BatchSize:      10,
+				OutputFormat:   "json",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save original values
+			originalArgs := os.Args
+			originalEnv := map[string]string{}
+
+			// Set environment variables
+			for key, value := range tt.envVars {
+				originalEnv[key] = os.Getenv(key)
+				os.Setenv(key, value)
+			}
+
+			// Set command line args
+			os.Args = tt.args
+
+			// Reset flag.CommandLine for testing
+			flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+
+			// Parse args
+			result := parseCommandLineArgs()
+
+			// Verify results
+			assert.Equal(t, tt.expected.Type, result.Type)
+			assert.Equal(t, tt.expected.ConfigRuleName, result.ConfigRuleName)
+			assert.Equal(t, tt.expected.Region, result.Region)
+			assert.Equal(t, tt.expected.BatchSize, result.BatchSize)
+			assert.Equal(t, tt.expected.DryRun, result.DryRun)
+			assert.Equal(t, tt.expected.OutputFormat, result.OutputFormat)
+
+			// Restore original values
+			os.Args = originalArgs
+			for key, value := range originalEnv {
+				if value == "" {
+					os.Unsetenv(key)
+				} else {
+					os.Setenv(key, value)
+				}
+			}
+			for key := range tt.envVars {
+				if _, exists := originalEnv[key]; !exists {
+					os.Unsetenv(key)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateInput(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   CommandInput
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid input",
+			input: CommandInput{
+				Type:           "config-rule-evaluation",
+				ConfigRuleName: "test-rule",
+				Region:         "us-east-1",
+				BatchSize:      10,
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid type",
+			input: CommandInput{
+				Type:           "invalid-type",
+				ConfigRuleName: "test-rule",
+				Region:         "us-east-1",
+				BatchSize:      10,
+			},
+			wantErr: true,
+			errMsg:  "unsupported request type",
+		},
+		{
+			name: "missing config rule name",
+			input: CommandInput{
+				Type:      "config-rule-evaluation",
+				Region:    "us-east-1",
+				BatchSize: 10,
+			},
+			wantErr: true,
+			errMsg:  "config rule name is required",
+		},
+		{
+			name: "missing region",
+			input: CommandInput{
+				Type:           "config-rule-evaluation",
+				ConfigRuleName: "test-rule",
+				BatchSize:      10,
+			},
+			wantErr: true,
+			errMsg:  "region is required",
+		},
+		{
+			name: "invalid batch size - zero",
+			input: CommandInput{
+				Type:           "config-rule-evaluation",
+				ConfigRuleName: "test-rule",
+				Region:         "us-east-1",
+				BatchSize:      0,
+			},
+			wantErr: true,
+			errMsg:  "batch size must be between 1 and 100",
+		},
+		{
+			name: "invalid batch size - too large",
+			input: CommandInput{
+				Type:           "config-rule-evaluation",
+				ConfigRuleName: "test-rule",
+				Region:         "us-east-1",
+				BatchSize:      101,
+			},
+			wantErr: true,
+			errMsg:  "batch size must be between 1 and 100",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateInput(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGetVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		expected string
+	}{
+		{
+			name:     "with version env var",
+			envValue: "1.2.3",
+			expected: "1.2.3",
+		},
+		{
+			name:     "without version env var",
+			envValue: "",
+			expected: "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalValue := os.Getenv("APP_VERSION")
+			defer func() {
+				if originalValue == "" {
+					os.Unsetenv("APP_VERSION")
+				} else {
+					os.Setenv("APP_VERSION", originalValue)
+				}
+			}()
+
+			if tt.envValue != "" {
+				os.Setenv("APP_VERSION", tt.envValue)
+			} else {
+				os.Unsetenv("APP_VERSION")
+			}
+
+			assert.Equal(t, tt.expected, getVersion())
+		})
+	}
+}
+
+func TestGetExecutionMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		dryRun   bool
+		expected string
+	}{
+		{
+			name:     "dry-run mode",
+			dryRun:   true,
+			expected: "dry-run",
+		},
+		{
+			name:     "apply mode",
+			dryRun:   false,
+			expected: "apply",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, getExecutionMode(tt.dryRun))
+		})
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,105 @@
+version: '3.8'
+
+services:
+  # Main LogGuardian container service
+  logguardian:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        VERSION: ${VERSION:-1.3.0}
+    image: logguardian:${VERSION:-latest}
+    container_name: logguardian-container
+    environment:
+      # AWS Configuration
+      AWS_REGION: ${AWS_REGION:-us-east-1}
+      AWS_PROFILE: ${AWS_PROFILE:-default}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN}
+      
+      # Application Configuration
+      CONFIG_RULE_NAME: ${CONFIG_RULE_NAME:-cloudwatch-log-group-encrypted}
+      BATCH_SIZE: ${BATCH_SIZE:-10}
+      DRY_RUN: ${DRY_RUN:-true}
+      
+      # Logging
+      LOG_LEVEL: ${LOG_LEVEL:-INFO}
+    volumes:
+      # Mount AWS credentials (read-only)
+      - ~/.aws:/home/logguardian/.aws:ro
+    command: [
+      "--config-rule", "${CONFIG_RULE_NAME:-cloudwatch-log-group-encrypted}",
+      "--region", "${AWS_REGION:-us-east-1}",
+      "--batch-size", "${BATCH_SIZE:-10}",
+      "--dry-run",
+      "--verbose",
+      "--output", "json"
+    ]
+    networks:
+      - logguardian-net
+    # Container exits after execution
+    restart: "no"
+
+  # Development container with shell access
+  logguardian-dev:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: builder
+    image: logguardian:dev
+    container_name: logguardian-dev
+    environment:
+      AWS_REGION: ${AWS_REGION:-us-east-1}
+      AWS_PROFILE: ${AWS_PROFILE:-default}
+    volumes:
+      - ~/.aws:/root/.aws:ro
+      - .:/workspace
+    working_dir: /workspace
+    command: /bin/sh
+    networks:
+      - logguardian-net
+    stdin_open: true
+    tty: true
+
+  # Test runner container
+  logguardian-test:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: builder
+    image: logguardian:test
+    container_name: logguardian-test
+    volumes:
+      - .:/workspace
+    working_dir: /workspace
+    command: go test -v ./...
+    networks:
+      - logguardian-net
+
+networks:
+  logguardian-net:
+    driver: bridge
+
+# Usage examples:
+# 
+# 1. Run in dry-run mode (default):
+#    docker-compose up logguardian
+#
+# 2. Run with specific config rule:
+#    CONFIG_RULE_NAME=my-rule docker-compose up logguardian
+#
+# 3. Run in apply mode (actual remediation):
+#    DRY_RUN=false docker-compose up logguardian
+#
+# 4. Run tests:
+#    docker-compose up logguardian-test
+#
+# 5. Access development shell:
+#    docker-compose run logguardian-dev
+#
+# 6. Build all images:
+#    docker-compose build
+#
+# 7. Clean up:
+#    docker-compose down -v --rmi all

--- a/docs/containerization-design.md
+++ b/docs/containerization-design.md
@@ -1,0 +1,404 @@
+# LogGuardian Containerization Design Document
+
+## Executive Summary
+
+This document outlines the design principles, architectural patterns, and implementation strategy for containerizing the LogGuardian Lambda application. The containerized version will maintain functional parity with the Lambda implementation while providing deployment flexibility across container orchestration platforms, starting with Amazon ECS.
+
+## Design Goals
+
+### Primary Objectives
+- **Functional Parity**: Maintain identical business logic and compliance remediation capabilities
+- **Platform Agnostic**: Design for portability across ECS, Kubernetes, and other container platforms
+- **Ephemeral Execution**: Run-to-completion pattern with automatic resource cleanup
+- **Configuration Flexibility**: Support multiple parameter injection methods
+- **Authentication Abstraction**: Seamless credential handling across environments
+
+### Non-Functional Requirements
+- **Performance**: Sub-second container startup time
+- **Security**: Principle of least privilege, no embedded credentials
+- **Observability**: Structured logging with correlation capabilities
+- **Cost Optimization**: Minimal resource allocation, pay-per-execution model
+- **Maintainability**: Single codebase for multiple deployment targets
+
+## Architectural Patterns
+
+### 1. Command Pattern Implementation
+
+The container will implement the Command Pattern, treating each execution as a discrete command with:
+- **Command Interface**: CLI arguments or environment variables as input
+- **Command Processor**: Core business logic from Lambda handler
+- **Command Result**: Exit codes and structured logs as output
+
+This pattern enables:
+- Decoupling of trigger mechanisms from business logic
+- Easy testing through command simulation
+- Clear separation of concerns
+
+### 2. Adapter Pattern for AWS Services
+
+An adapter layer will abstract AWS service interactions:
+- **Authentication Adapter**: Handles multiple credential sources
+- **Service Adapter**: Wraps AWS SDK calls with retry logic
+- **Configuration Adapter**: Normalizes configuration from various sources
+
+Benefits:
+- Simplified testing with mock adapters
+- Consistent error handling
+- Platform-specific optimizations
+
+### 3. Strategy Pattern for Authentication
+
+Multiple authentication strategies will be supported through a common interface:
+- **Task Role Strategy**: For ECS/Fargate deployments
+- **Profile Strategy**: For local development
+- **Environment Strategy**: For CI/CD pipelines
+- **Instance Profile Strategy**: For EC2 deployments
+
+The appropriate strategy is selected at runtime based on environment detection.
+
+## Design Decisions
+
+### Container vs Serverless Trade-offs
+
+| Aspect | Lambda (Current) | Container (Proposed) | Decision Rationale |
+|--------|------------------|---------------------|-------------------|
+| **Startup Time** | Cold start (~1s) | Container pull + start (~3-5s) | Acceptable for batch processing |
+| **Execution Limit** | 15 minutes | Unlimited | Enables future long-running tasks |
+| **Deployment** | Function code only | Full container image | Better dependency control |
+| **Scaling** | Automatic | Orchestrator-dependent | Predictable workload doesn't need auto-scaling |
+| **Cost Model** | Per invocation | Per execution time | Similar costs for short tasks |
+
+### Ephemeral vs Long-Running Design
+
+**Decision: Ephemeral (Run-to-Completion)**
+
+Rationale:
+- Matches current Lambda execution model
+- Simplifies state management (stateless)
+- Reduces attack surface (short-lived containers)
+- Optimizes costs (no idle resources)
+- Enables easy migration between platforms
+
+### Configuration Injection Methods
+
+**Primary Method: CLI Arguments**
+- Clear contract definition
+- Easy to test and debug
+- Platform agnostic
+- Supports complex parameter structures
+- Includes --dry-run flag for safe testing
+
+**Secondary Method: Environment Variables**
+- AWS service configuration (regions, endpoints)
+- Feature flags and operational settings
+- Secrets from orchestrator secret management
+
+**Avoided: Configuration Files**
+- Adds complexity to image building
+- Reduces deployment flexibility
+- Complicates secret management
+
+## Authentication Architecture
+
+### Credential Chain Design
+
+The container will implement a hierarchical credential resolution pattern:
+
+1. **Explicit Credentials** (highest priority)
+   - Command-line specified profiles
+   - Directly provided credentials
+
+2. **Implicit Container Credentials**
+   - ECS task roles via metadata service
+   - Kubernetes service accounts via IRSA
+   
+3. **Environment Credentials**
+   - Standard AWS environment variables
+   - Temporary session tokens
+
+4. **Default Credentials** (lowest priority)
+   - EC2 instance profiles
+   - Default profile from credentials file
+
+### Security Principles
+
+- **No Embedded Credentials**: Images never contain AWS credentials
+- **Temporary Credentials Only**: Use STS tokens with time limits
+- **Least Privilege**: Task roles with minimal required permissions
+- **Credential Isolation**: Separate roles for different environments
+
+## Container Image Design
+
+### Base Image Selection
+
+**Decision: Alpine Linux**
+
+Rationale:
+- Minimal attack surface (~5MB base)
+- Fast download and startup
+- Sufficient for Go static binaries
+- Active security maintenance
+
+### Build Strategy
+
+**Multi-Stage Build Pattern**
+- **Build Stage**: Full development environment
+- **Runtime Stage**: Minimal runtime dependencies
+
+Benefits:
+- Smaller final images (~20MB total)
+- No build tools in production
+- Consistent build environment
+- Cached layer optimization
+
+### User and Permission Model
+
+- Run as non-root user (UID 1000)
+- Read-only root filesystem capability
+- Explicit directory permissions for required paths
+- No sudo or privilege escalation
+
+## Orchestration Integration
+
+### ECS/Fargate Design
+
+**Task Definition Pattern**
+- Single container per task
+- Task-level IAM roles
+- CloudWatch Logs integration
+- Health check endpoints
+
+**Triggering Mechanisms**
+1. EventBridge → ECS RunTask
+2. Lambda Orchestrator → ECS API
+3. Step Functions → ECS Task State
+4. Manual invocation via CLI/Console
+
+### Future Kubernetes Design
+
+**Job/CronJob Pattern**
+- Kubernetes Job for one-time execution
+- CronJob for scheduled runs
+- ConfigMap for configuration
+- ServiceAccount for AWS permissions (IRSA)
+
+**Key Differences from ECS**
+- Pod security policies
+- Network policies for isolation
+- Prometheus metrics vs CloudWatch
+
+## Monitoring and Observability
+
+### Logging Strategy
+
+**Structured Logging**
+- JSON format for machine parsing
+- Correlation IDs for request tracing
+- Log levels: ERROR, WARN, INFO, DEBUG
+- Contextual fields for filtering
+
+**Log Aggregation**
+- CloudWatch Logs (ECS)
+- Fluentd/Elasticsearch (Kubernetes)
+- Consistent format across platforms
+
+### Metrics Collection
+
+**Key Metrics**
+- Task execution count
+- Processing duration
+- Success/failure rates
+- Resource utilization
+
+**Collection Methods**
+- CloudWatch Metrics (AWS)
+- Prometheus (Kubernetes)
+- StatsD (platform agnostic)
+
+### Distributed Tracing
+
+- AWS X-Ray integration for ECS
+- OpenTelemetry for platform independence
+- Trace context propagation
+
+## Migration Strategy
+
+### Phase 1: Parallel Development
+- Maintain Lambda function unchanged
+- Develop container version with same inputs/outputs
+- Establish testing parity benchmarks
+
+### Phase 2: Shadow Testing
+- Deploy container to non-production
+- Run both implementations in parallel
+- Compare results and performance
+- Validate compliance outcomes
+
+### Phase 3: Gradual Rollout
+- Start with non-critical Config rules
+- Monitor for 1-2 weeks per rule
+- Progressive migration based on success criteria
+- Maintain rollback capability
+
+### Phase 4: Decommissioning
+- Remove Lambda infrastructure
+- Archive serverless templates
+- Update documentation and runbooks
+
+## Testing Strategy
+
+### Unit Testing
+- Mock AWS service calls
+- Test command parsing logic
+- Validate error handling
+
+### Integration Testing
+- Local container execution
+- AWS service integration with test accounts
+- End-to-end compliance scenarios
+
+### Performance Testing
+- Container startup time benchmarks
+- Memory and CPU profiling
+- Concurrent execution limits
+
+### Security Testing
+- Container vulnerability scanning
+- IAM permission validation
+- Network isolation verification
+
+## Cost Optimization
+
+### Resource Sizing
+- Start with minimal allocations (256 CPU, 512MB RAM)
+- Monitor actual usage patterns
+- Right-size based on p95 metrics
+
+### Execution Optimization
+- Batch processing to reduce invocations
+- Parallel processing within limits
+- Early termination on errors
+
+### Platform Selection
+- Fargate Spot for non-critical workloads
+- Reserved capacity for predictable schedules
+- Consider EC2 for high-volume scenarios
+
+## Risk Analysis
+
+### Technical Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Container startup delays | Missed SLA | Pre-pulled images, warm pools |
+| Authentication failures | Service disruption | Multiple auth methods, fallbacks |
+| Resource exhaustion | Task failures | Limits, monitoring, auto-scaling |
+| Network issues | API call failures | Retries, circuit breakers |
+
+### Operational Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Complex debugging | Longer MTTR | Comprehensive logging, tracing |
+| Deployment failures | Service unavailability | Blue-green deployments, rollback |
+| Configuration drift | Inconsistent behavior | GitOps, infrastructure as code |
+
+## Success Criteria
+
+### Functional Success
+- 100% parity with Lambda functionality
+- Same compliance remediation outcomes
+- No regression in error rates
+- Idempotent operations (safe to re-run)
+- Execution reports generated for each run
+
+### Performance Success
+- Container startup < 5 seconds
+- Processing time within 10% of Lambda
+- Memory usage < 256MB
+- Handles AWS API rate limiting gracefully
+
+### Operational Success
+- Deployment time < 5 minutes
+- Clear error notifications to ops team
+- Audit trail of all compliance changes
+- Dry-run mode validates changes before applying
+
+## Future Enhancements
+
+### Short Term (3-6 months)
+- Kubernetes deployment support
+- Multi-region container registries
+- Enhanced observability dashboards
+
+### Medium Term (6-12 months)
+- Sidecar pattern for monitoring
+- Service mesh integration
+- Automated performance tuning
+
+### Long Term (12+ months)
+- Multi-cloud support (Azure, GCP)
+- Native cloud service integrations
+- AI-driven optimization
+
+## Decision Log
+
+| Date | Decision | Rationale | Alternatives Considered |
+|------|----------|-----------|------------------------|
+| TBD | CLI-based interface | Simplicity, testability | HTTP API, Message queue |
+| TBD | Alpine base image | Security, size | Distroless, Ubuntu |
+| TBD | ECS Fargate | Serverless containers | EC2, Kubernetes |
+| TBD | Multi-stage builds | Image optimization | Single stage, BuildKit |
+| TBD | Idempotent operations | Safe re-runs for weekly jobs | Stateful tracking |
+| TBD | Dry-run mode | Safe testing of compliance changes | Direct execution only |
+
+## Appendices
+
+### A. IAM Permission Matrix
+
+Define minimum required permissions for:
+- ECS Task Role
+- EventBridge Execution Role
+- Container Repository Access
+- CloudWatch Logs Access
+
+### B. Network Architecture
+
+- VPC requirements
+- Security group rules
+- PrivateLink endpoints
+- Internet Gateway needs
+
+### C. Disaster Recovery
+
+- Backup strategies
+- Recovery time objectives
+- Failover procedures
+- Data consistency guarantees
+
+## Key Implementation Requirements
+
+### Essential Features for Weekly Compliance Jobs
+1. **Idempotency**: All operations must be safe to re-run without side effects
+2. **Dry-run Mode**: `--dry-run` flag to preview changes without applying them
+3. **Execution Reporting**: Generate JSON reports of processed/compliant/failed resources
+4. **Rate Limiting**: Implement exponential backoff for AWS API throttling
+5. **Error Notifications**: SNS/Slack integration for failure alerts
+6. **Audit Logging**: Track all compliance changes with execution ID and timestamp
+
+## Approval and Sign-off
+
+| Role | Name | Date | Signature |
+|------|------|------|-----------|
+| Technical Lead | | | |
+| Security Architect | | | |
+| DevOps Lead | | | |
+| Product Owner | | | |
+
+---
+
+**Document Version**: 1.0.0  
+**Last Updated**: 2024  
+**Status**: Draft - Pending Review  
+**Classification**: Internal  
+**Review Cycle**: Quarterly

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 )
 
 require (
-	github.com/aws/aws-sdk-go-v2/credentials v1.16.12 // indirect
+	github.com/aws/aws-sdk-go-v2/credentials v1.16.12
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.14.10 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.3 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.3 // indirect
@@ -30,6 +30,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.10.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.18.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.21.5 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.26.5 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sts v1.26.5
 	github.com/aws/smithy-go v1.22.5
 )

--- a/internal/container/auth.go
+++ b/internal/container/auth.go
@@ -1,0 +1,246 @@
+package container
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+)
+
+type AuthenticationStrategy struct {
+	strategies []AuthStrategy
+}
+
+type AuthStrategy interface {
+	Name() string
+	IsAvailable(ctx context.Context, options AuthOptions) bool
+	GetConfig(ctx context.Context, options AuthOptions) (aws.Config, error)
+	Priority() int
+}
+
+type AuthOptions struct {
+	Profile    string
+	AssumeRole string
+	Region     string
+}
+
+func NewAuthenticationStrategy() *AuthenticationStrategy {
+	return &AuthenticationStrategy{
+		strategies: []AuthStrategy{
+			&ExplicitCredentialsStrategy{},
+			&ProfileStrategy{},
+			&AssumeRoleStrategy{},
+			&TaskRoleStrategy{},
+			&EnvironmentStrategy{},
+			&InstanceProfileStrategy{},
+			&DefaultStrategy{},
+		},
+	}
+}
+
+func (a *AuthenticationStrategy) GetAWSConfig(ctx context.Context, options AuthOptions) (aws.Config, error) {
+	slog.Info("Resolving AWS credentials",
+		"profile", options.Profile,
+		"assume_role", options.AssumeRole,
+		"region", options.Region)
+
+	// Try strategies in order of priority
+	for _, strategy := range a.strategies {
+		if strategy.IsAvailable(ctx, options) {
+			slog.Info("Attempting authentication strategy",
+				"strategy", strategy.Name(),
+				"priority", strategy.Priority())
+
+			cfg, err := strategy.GetConfig(ctx, options)
+			if err == nil {
+				slog.Info("Successfully authenticated",
+					"strategy", strategy.Name(),
+					"region", options.Region)
+				return cfg, nil
+			}
+
+			slog.Warn("Strategy failed",
+				"strategy", strategy.Name(),
+				"error", err)
+		}
+	}
+
+	return aws.Config{}, fmt.Errorf("no valid authentication method found")
+}
+
+// ExplicitCredentialsStrategy handles explicitly provided credentials
+type ExplicitCredentialsStrategy struct{}
+
+func (s *ExplicitCredentialsStrategy) Name() string  { return "explicit-credentials" }
+func (s *ExplicitCredentialsStrategy) Priority() int { return 1 }
+
+func (s *ExplicitCredentialsStrategy) IsAvailable(ctx context.Context, options AuthOptions) bool {
+	// Check if explicit credentials are provided via environment
+	accessKey := os.Getenv("AWS_ACCESS_KEY_ID")
+	secretKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
+	return accessKey != "" && secretKey != ""
+}
+
+func (s *ExplicitCredentialsStrategy) GetConfig(ctx context.Context, options AuthOptions) (aws.Config, error) {
+	accessKey := os.Getenv("AWS_ACCESS_KEY_ID")
+	secretKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
+	sessionToken := os.Getenv("AWS_SESSION_TOKEN")
+
+	opts := []func(*config.LoadOptions) error{
+		config.WithRegion(options.Region),
+		config.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider(accessKey, secretKey, sessionToken),
+		),
+	}
+
+	return config.LoadDefaultConfig(ctx, opts...)
+}
+
+// ProfileStrategy handles AWS profile-based authentication
+type ProfileStrategy struct{}
+
+func (s *ProfileStrategy) Name() string  { return "profile" }
+func (s *ProfileStrategy) Priority() int { return 2 }
+
+func (s *ProfileStrategy) IsAvailable(ctx context.Context, options AuthOptions) bool {
+	return options.Profile != ""
+}
+
+func (s *ProfileStrategy) GetConfig(ctx context.Context, options AuthOptions) (aws.Config, error) {
+	opts := []func(*config.LoadOptions) error{
+		config.WithRegion(options.Region),
+		config.WithSharedConfigProfile(options.Profile),
+	}
+
+	return config.LoadDefaultConfig(ctx, opts...)
+}
+
+// AssumeRoleStrategy handles IAM role assumption
+type AssumeRoleStrategy struct{}
+
+func (s *AssumeRoleStrategy) Name() string  { return "assume-role" }
+func (s *AssumeRoleStrategy) Priority() int { return 3 }
+
+func (s *AssumeRoleStrategy) IsAvailable(ctx context.Context, options AuthOptions) bool {
+	return options.AssumeRole != ""
+}
+
+func (s *AssumeRoleStrategy) GetConfig(ctx context.Context, options AuthOptions) (aws.Config, error) {
+	// First get base config
+	baseCfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(options.Region))
+	if err != nil {
+		return aws.Config{}, fmt.Errorf("failed to load base config: %w", err)
+	}
+
+	// Create STS client
+	stsClient := sts.NewFromConfig(baseCfg)
+
+	// Create assume role provider
+	roleProvider := stscreds.NewAssumeRoleProvider(stsClient, options.AssumeRole,
+		func(o *stscreds.AssumeRoleOptions) {
+			o.RoleSessionName = "logguardian-container"
+		})
+
+	// Return config with assumed role credentials
+	return config.LoadDefaultConfig(ctx,
+		config.WithRegion(options.Region),
+		config.WithCredentialsProvider(roleProvider),
+	)
+}
+
+// TaskRoleStrategy handles ECS/Fargate task role authentication
+type TaskRoleStrategy struct{}
+
+func (s *TaskRoleStrategy) Name() string  { return "ecs-task-role" }
+func (s *TaskRoleStrategy) Priority() int { return 4 }
+
+func (s *TaskRoleStrategy) IsAvailable(ctx context.Context, options AuthOptions) bool {
+	// Check if running in ECS by looking for ECS metadata URI
+	metadataURI := os.Getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
+	if metadataURI != "" {
+		return true
+	}
+
+	// Check for ECS full URI (Fargate)
+	fullURI := os.Getenv("AWS_CONTAINER_CREDENTIALS_FULL_URI")
+	return fullURI != ""
+}
+
+func (s *TaskRoleStrategy) GetConfig(ctx context.Context, options AuthOptions) (aws.Config, error) {
+	// AWS SDK automatically handles ECS task role credentials
+	return config.LoadDefaultConfig(ctx, config.WithRegion(options.Region))
+}
+
+// EnvironmentStrategy handles environment variable authentication
+type EnvironmentStrategy struct{}
+
+func (s *EnvironmentStrategy) Name() string  { return "environment" }
+func (s *EnvironmentStrategy) Priority() int { return 5 }
+
+func (s *EnvironmentStrategy) IsAvailable(ctx context.Context, options AuthOptions) bool {
+	// Check if AWS credentials are in environment (but not explicit)
+	// This catches cases where credentials are set but not via AWS_ACCESS_KEY_ID
+	_, hasProfile := os.LookupEnv("AWS_PROFILE")
+	return hasProfile && options.Profile == ""
+}
+
+func (s *EnvironmentStrategy) GetConfig(ctx context.Context, options AuthOptions) (aws.Config, error) {
+	return config.LoadDefaultConfig(ctx, config.WithRegion(options.Region))
+}
+
+// InstanceProfileStrategy handles EC2 instance profile authentication
+type InstanceProfileStrategy struct{}
+
+func (s *InstanceProfileStrategy) Name() string  { return "ec2-instance-profile" }
+func (s *InstanceProfileStrategy) Priority() int { return 6 }
+
+func (s *InstanceProfileStrategy) IsAvailable(ctx context.Context, options AuthOptions) bool {
+	// Try to detect if running on EC2
+	// This is a heuristic - the SDK will handle the actual detection
+	hostname, _ := os.Hostname()
+	return hostname != "" && isEC2Instance()
+}
+
+func (s *InstanceProfileStrategy) GetConfig(ctx context.Context, options AuthOptions) (aws.Config, error) {
+	// AWS SDK automatically handles EC2 instance profile credentials
+	return config.LoadDefaultConfig(ctx, config.WithRegion(options.Region))
+}
+
+// DefaultStrategy is the fallback authentication method
+type DefaultStrategy struct{}
+
+func (s *DefaultStrategy) Name() string  { return "default" }
+func (s *DefaultStrategy) Priority() int { return 99 }
+
+func (s *DefaultStrategy) IsAvailable(ctx context.Context, options AuthOptions) bool {
+	// Always available as last resort
+	return true
+}
+
+func (s *DefaultStrategy) GetConfig(ctx context.Context, options AuthOptions) (aws.Config, error) {
+	// Try default credential chain
+	return config.LoadDefaultConfig(ctx, config.WithRegion(options.Region))
+}
+
+// isEC2Instance attempts to detect if running on EC2
+func isEC2Instance() bool {
+	// Check for EC2 metadata service
+	// This is a simple heuristic - the SDK does more robust detection
+	if _, err := os.Stat("/sys/devices/virtual/dmi/id/product_uuid"); err == nil {
+		return true
+	}
+
+	// Check for AWS_EXECUTION_ENV
+	if env := os.Getenv("AWS_EXECUTION_ENV"); env != "" {
+		return true
+	}
+
+	// Check IMDSv2 endpoint availability would be done by SDK
+	return false
+}

--- a/internal/container/auth_test.go
+++ b/internal/container/auth_test.go
@@ -1,0 +1,308 @@
+package container
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuthenticationStrategy_Priority(t *testing.T) {
+	strategies := []AuthStrategy{
+		&ExplicitCredentialsStrategy{},
+		&ProfileStrategy{},
+		&AssumeRoleStrategy{},
+		&TaskRoleStrategy{},
+		&EnvironmentStrategy{},
+		&InstanceProfileStrategy{},
+		&DefaultStrategy{},
+	}
+
+	expectedPriorities := []int{1, 2, 3, 4, 5, 6, 99}
+
+	for i, strategy := range strategies {
+		assert.Equal(t, expectedPriorities[i], strategy.Priority(), "Strategy %s has wrong priority", strategy.Name())
+	}
+}
+
+func TestExplicitCredentialsStrategy(t *testing.T) {
+	strategy := &ExplicitCredentialsStrategy{}
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		envVars     map[string]string
+		isAvailable bool
+	}{
+		{
+			name: "with explicit credentials",
+			envVars: map[string]string{
+				"AWS_ACCESS_KEY_ID":     "test-key",
+				"AWS_SECRET_ACCESS_KEY": "test-secret",
+			},
+			isAvailable: true,
+		},
+		{
+			name: "missing access key",
+			envVars: map[string]string{
+				"AWS_SECRET_ACCESS_KEY": "test-secret",
+			},
+			isAvailable: false,
+		},
+		{
+			name: "missing secret key",
+			envVars: map[string]string{
+				"AWS_ACCESS_KEY_ID": "test-key",
+			},
+			isAvailable: false,
+		},
+		{
+			name:        "no credentials",
+			envVars:     map[string]string{},
+			isAvailable: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save and restore environment
+			originalEnv := saveEnvironment([]string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"})
+			defer restoreEnvironment(originalEnv)
+
+			// Set test environment
+			for key, value := range tt.envVars {
+				os.Setenv(key, value)
+			}
+
+			options := AuthOptions{Region: "us-east-1"}
+			assert.Equal(t, tt.isAvailable, strategy.IsAvailable(ctx, options))
+		})
+	}
+}
+
+func TestProfileStrategy(t *testing.T) {
+	strategy := &ProfileStrategy{}
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		options     AuthOptions
+		isAvailable bool
+	}{
+		{
+			name: "with profile",
+			options: AuthOptions{
+				Profile: "test-profile",
+				Region:  "us-east-1",
+			},
+			isAvailable: true,
+		},
+		{
+			name: "without profile",
+			options: AuthOptions{
+				Region: "us-east-1",
+			},
+			isAvailable: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.isAvailable, strategy.IsAvailable(ctx, tt.options))
+		})
+	}
+}
+
+func TestAssumeRoleStrategy(t *testing.T) {
+	strategy := &AssumeRoleStrategy{}
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		options     AuthOptions
+		isAvailable bool
+	}{
+		{
+			name: "with assume role",
+			options: AuthOptions{
+				AssumeRole: "arn:aws:iam::123456789012:role/test-role",
+				Region:     "us-east-1",
+			},
+			isAvailable: true,
+		},
+		{
+			name: "without assume role",
+			options: AuthOptions{
+				Region: "us-east-1",
+			},
+			isAvailable: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.isAvailable, strategy.IsAvailable(ctx, tt.options))
+		})
+	}
+}
+
+func TestTaskRoleStrategy(t *testing.T) {
+	strategy := &TaskRoleStrategy{}
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		envVars     map[string]string
+		isAvailable bool
+	}{
+		{
+			name: "with ECS relative URI",
+			envVars: map[string]string{
+				"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "/v2/credentials/task-id",
+			},
+			isAvailable: true,
+		},
+		{
+			name: "with ECS full URI",
+			envVars: map[string]string{
+				"AWS_CONTAINER_CREDENTIALS_FULL_URI": "http://169.254.170.2/v2/credentials/task-id",
+			},
+			isAvailable: true,
+		},
+		{
+			name:        "without ECS metadata",
+			envVars:     map[string]string{},
+			isAvailable: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save and restore environment
+			originalEnv := saveEnvironment([]string{
+				"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+				"AWS_CONTAINER_CREDENTIALS_FULL_URI",
+			})
+			defer restoreEnvironment(originalEnv)
+
+			// Clear environment
+			os.Unsetenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
+			os.Unsetenv("AWS_CONTAINER_CREDENTIALS_FULL_URI")
+
+			// Set test environment
+			for key, value := range tt.envVars {
+				os.Setenv(key, value)
+			}
+
+			options := AuthOptions{Region: "us-east-1"}
+			assert.Equal(t, tt.isAvailable, strategy.IsAvailable(ctx, options))
+		})
+	}
+}
+
+func TestEnvironmentStrategy(t *testing.T) {
+	strategy := &EnvironmentStrategy{}
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		envVars     map[string]string
+		options     AuthOptions
+		isAvailable bool
+	}{
+		{
+			name: "with AWS_PROFILE env var and no profile option",
+			envVars: map[string]string{
+				"AWS_PROFILE": "env-profile",
+			},
+			options:     AuthOptions{Region: "us-east-1"},
+			isAvailable: true,
+		},
+		{
+			name: "with AWS_PROFILE env var but profile option set",
+			envVars: map[string]string{
+				"AWS_PROFILE": "env-profile",
+			},
+			options: AuthOptions{
+				Profile: "cli-profile",
+				Region:  "us-east-1",
+			},
+			isAvailable: false,
+		},
+		{
+			name:        "without AWS_PROFILE",
+			envVars:     map[string]string{},
+			options:     AuthOptions{Region: "us-east-1"},
+			isAvailable: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save and restore environment
+			originalEnv := saveEnvironment([]string{"AWS_PROFILE"})
+			defer restoreEnvironment(originalEnv)
+
+			// Clear and set test environment
+			os.Unsetenv("AWS_PROFILE")
+			for key, value := range tt.envVars {
+				os.Setenv(key, value)
+			}
+
+			assert.Equal(t, tt.isAvailable, strategy.IsAvailable(ctx, tt.options))
+		})
+	}
+}
+
+func TestDefaultStrategy(t *testing.T) {
+	strategy := &DefaultStrategy{}
+	ctx := context.Background()
+
+	// Default strategy should always be available
+	options := AuthOptions{Region: "us-east-1"}
+	assert.True(t, strategy.IsAvailable(ctx, options))
+	assert.Equal(t, "default", strategy.Name())
+	assert.Equal(t, 99, strategy.Priority())
+}
+
+func TestNewAuthenticationStrategy(t *testing.T) {
+	authStrategy := NewAuthenticationStrategy()
+
+	assert.NotNil(t, authStrategy)
+	assert.Len(t, authStrategy.strategies, 7)
+
+	// Verify strategies are in correct order
+	expectedNames := []string{
+		"explicit-credentials",
+		"profile",
+		"assume-role",
+		"ecs-task-role",
+		"environment",
+		"ec2-instance-profile",
+		"default",
+	}
+
+	for i, expectedName := range expectedNames {
+		assert.Equal(t, expectedName, authStrategy.strategies[i].Name())
+	}
+}
+
+// Helper functions for environment management
+func saveEnvironment(keys []string) map[string]string {
+	saved := make(map[string]string)
+	for _, key := range keys {
+		saved[key] = os.Getenv(key)
+	}
+	return saved
+}
+
+func restoreEnvironment(saved map[string]string) {
+	for key, value := range saved {
+		if value == "" {
+			os.Unsetenv(key)
+		} else {
+			os.Setenv(key, value)
+		}
+	}
+}

--- a/internal/container/dryrun.go
+++ b/internal/container/dryrun.go
@@ -1,0 +1,147 @@
+package container
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/zsoftly/logguardian/internal/service"
+	"github.com/zsoftly/logguardian/internal/types"
+)
+
+// DryRunComplianceService wraps the real compliance service for dry-run mode
+type DryRunComplianceService struct {
+	realService service.ComplianceServiceInterface
+}
+
+// NewDryRunComplianceService creates a new dry-run wrapper for the compliance service
+func NewDryRunComplianceService(realService service.ComplianceServiceInterface) *DryRunComplianceService {
+	return &DryRunComplianceService{
+		realService: realService,
+	}
+}
+
+// GetNonCompliantResources delegates to the real service (read-only operation)
+func (s *DryRunComplianceService) GetNonCompliantResources(ctx context.Context, configRuleName, region string) ([]types.NonCompliantResource, error) {
+	slog.Info("[DRY-RUN] Getting non-compliant resources",
+		"config_rule", configRuleName,
+		"region", region)
+	return s.realService.GetNonCompliantResources(ctx, configRuleName, region)
+}
+
+// ValidateResourceExistence delegates to the real service (read-only operation)
+func (s *DryRunComplianceService) ValidateResourceExistence(ctx context.Context, resources []types.NonCompliantResource) ([]types.NonCompliantResource, error) {
+	slog.Info("[DRY-RUN] Validating resource existence",
+		"resource_count", len(resources))
+	return s.realService.ValidateResourceExistence(ctx, resources)
+}
+
+// RemediateLogGroup simulates remediation without making changes
+func (s *DryRunComplianceService) RemediateLogGroup(ctx context.Context, compliance types.ComplianceResult) (*types.RemediationResult, error) {
+	slog.Info("[DRY-RUN] Would remediate log group",
+		"log_group", compliance.LogGroupName,
+		"missing_encryption", compliance.MissingEncryption,
+		"missing_retention", compliance.MissingRetention)
+
+	result := types.RemediationResult{
+		LogGroupName:      compliance.LogGroupName,
+		Region:            compliance.Region,
+		EncryptionApplied: compliance.MissingEncryption,
+		RetentionApplied:  compliance.MissingRetention,
+		Success:           true,
+		Error:             nil,
+	}
+
+	if compliance.MissingEncryption {
+		slog.Info("[DRY-RUN] Would apply encryption",
+			"log_group", compliance.LogGroupName,
+			"region", compliance.Region)
+	}
+
+	if compliance.MissingRetention {
+		slog.Info("[DRY-RUN] Would apply retention",
+			"log_group", compliance.LogGroupName,
+			"region", compliance.Region,
+			"retention_days", 7)
+	}
+
+	if !compliance.MissingEncryption && !compliance.MissingRetention {
+		slog.Info("[DRY-RUN] Log group already compliant",
+			"log_group", compliance.LogGroupName)
+	}
+
+	return &result, nil
+}
+
+// ProcessNonCompliantResourcesOptimized simulates batch processing without making changes
+func (s *DryRunComplianceService) ProcessNonCompliantResourcesOptimized(ctx context.Context, request types.BatchComplianceRequest) (*types.BatchRemediationResult, error) {
+	slog.Info("[DRY-RUN] Would process non-compliant resources",
+		"config_rule", request.ConfigRuleName,
+		"region", request.Region,
+		"resource_count", len(request.NonCompliantResults),
+		"batch_size", request.BatchSize)
+
+	result := types.BatchRemediationResult{
+		TotalProcessed: len(request.NonCompliantResults),
+		Results:        []types.RemediationResult{},
+	}
+
+	// Simulate processing each resource
+	for _, resource := range request.NonCompliantResults {
+		slog.Info("[DRY-RUN] Would process resource",
+			"resource_id", resource.ResourceId,
+			"resource_name", resource.ResourceName,
+			"resource_type", resource.ResourceType)
+
+		// Create a simulated remediation result
+		remediationResult := types.RemediationResult{
+			LogGroupName:      resource.ResourceName,
+			Region:            resource.Region,
+			EncryptionApplied: false, // Would be determined by actual analysis
+			RetentionApplied:  false, // Would be determined by actual analysis
+			Success:           true,
+			Error:             nil,
+		}
+
+		// Simulate determining what would be applied based on the rule
+		if resource.Annotation != "" {
+			// Parse annotation to determine what's missing
+			// This is simplified - real implementation would analyze the actual state
+			remediationResult.EncryptionApplied = true
+			remediationResult.RetentionApplied = true
+		}
+
+		result.Results = append(result.Results, remediationResult)
+		result.SuccessCount++
+	}
+
+	slog.Info("[DRY-RUN] Batch processing simulation complete",
+		"total_processed", result.TotalProcessed,
+		"success_count", result.SuccessCount,
+		"failure_count", result.FailureCount)
+
+	return &result, nil
+}
+
+// EvaluateCompliance is not implemented for dry-run service
+// This method is not used in the container implementation as compliance evaluation
+// is handled differently through GetNonCompliantResources and ValidateResourceExistence
+func (s *DryRunComplianceService) EvaluateCompliance(ctx context.Context, logGroupName, region string) (types.ComplianceResult, error) {
+	slog.Warn("[DRY-RUN] EvaluateCompliance called but not implemented",
+		"log_group", logGroupName,
+		"region", region,
+		"note", "This method is not used in container implementation")
+
+	// Return empty result - this method should not be called in container mode
+	// Container mode uses GetNonCompliantResources for compliance evaluation
+	return types.ComplianceResult{}, fmt.Errorf("EvaluateCompliance is not implemented for container dry-run mode - use GetNonCompliantResources instead")
+}
+
+// GetLogGroupConfiguration is a helper method for dry-run analysis
+func (s *DryRunComplianceService) GetLogGroupConfiguration(ctx context.Context, logGroupName, region string) (types.LogGroupConfiguration, error) {
+	// This would need to be implemented to fetch actual configuration
+	// For now, return a placeholder
+	return types.LogGroupConfiguration{
+		LogGroupName: logGroupName,
+	}, nil
+}

--- a/internal/container/dryrun_test.go
+++ b/internal/container/dryrun_test.go
@@ -1,0 +1,217 @@
+package container
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zsoftly/logguardian/internal/types"
+)
+
+func TestNewDryRunComplianceService(t *testing.T) {
+	mockService := new(MockComplianceService)
+	dryRunService := NewDryRunComplianceService(mockService)
+
+	assert.NotNil(t, dryRunService)
+	assert.Equal(t, mockService, dryRunService.realService)
+}
+
+func TestDryRunComplianceService_GetNonCompliantResources(t *testing.T) {
+	ctx := context.Background()
+	mockService := new(MockComplianceService)
+	dryRunService := NewDryRunComplianceService(mockService)
+
+	expectedResources := []types.NonCompliantResource{
+		{
+			ResourceId:   "log-group-1",
+			ResourceName: "log-group-1",
+			ResourceType: "AWS::Logs::LogGroup",
+			Region:       "us-east-1",
+		},
+		{
+			ResourceId:   "log-group-2",
+			ResourceName: "log-group-2",
+			ResourceType: "AWS::Logs::LogGroup",
+			Region:       "us-east-1",
+		},
+	}
+
+	mockService.On("GetNonCompliantResources", ctx, "test-rule", "us-east-1").
+		Return(expectedResources, nil)
+
+	// This should delegate to the real service
+	result, err := dryRunService.GetNonCompliantResources(ctx, "test-rule", "us-east-1")
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResources, result)
+	mockService.AssertExpectations(t)
+}
+
+func TestDryRunComplianceService_ValidateResourceExistence(t *testing.T) {
+	ctx := context.Background()
+	mockService := new(MockComplianceService)
+	dryRunService := NewDryRunComplianceService(mockService)
+
+	inputResources := []types.NonCompliantResource{
+		{ResourceId: "log-group-1", ResourceName: "log-group-1"},
+		{ResourceId: "log-group-2", ResourceName: "log-group-2"},
+	}
+
+	expectedResources := []types.NonCompliantResource{
+		{ResourceId: "log-group-1", ResourceName: "log-group-1"},
+	}
+
+	mockService.On("ValidateResourceExistence", ctx, inputResources).
+		Return(expectedResources, nil)
+
+	// This should delegate to the real service
+	result, err := dryRunService.ValidateResourceExistence(ctx, inputResources)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResources, result)
+	mockService.AssertExpectations(t)
+}
+
+func TestDryRunComplianceService_RemediateLogGroup(t *testing.T) {
+	ctx := context.Background()
+	dryRunService := NewDryRunComplianceService(nil) // Don't need real service for dry-run
+
+	tests := []struct {
+		name       string
+		compliance types.ComplianceResult
+		expected   *types.RemediationResult
+	}{
+		{
+			name: "needs encryption and retention",
+			compliance: types.ComplianceResult{
+				LogGroupName:      "test-log-group",
+				Region:            "us-east-1",
+				MissingEncryption: true,
+				MissingRetention:  true,
+			},
+			expected: &types.RemediationResult{
+				LogGroupName:      "test-log-group",
+				Region:            "us-east-1",
+				EncryptionApplied: true,
+				RetentionApplied:  true,
+				Success:           true,
+				Error:             nil,
+			},
+		},
+		{
+			name: "needs only encryption",
+			compliance: types.ComplianceResult{
+				LogGroupName:      "test-log-group",
+				Region:            "us-east-1",
+				MissingEncryption: true,
+				MissingRetention:  false,
+			},
+			expected: &types.RemediationResult{
+				LogGroupName:      "test-log-group",
+				Region:            "us-east-1",
+				EncryptionApplied: true,
+				RetentionApplied:  false,
+				Success:           true,
+				Error:             nil,
+			},
+		},
+		{
+			name: "needs only retention",
+			compliance: types.ComplianceResult{
+				LogGroupName:      "test-log-group",
+				Region:            "us-east-1",
+				MissingEncryption: false,
+				MissingRetention:  true,
+			},
+			expected: &types.RemediationResult{
+				LogGroupName:      "test-log-group",
+				Region:            "us-east-1",
+				EncryptionApplied: false,
+				RetentionApplied:  true,
+				Success:           true,
+				Error:             nil,
+			},
+		},
+		{
+			name: "already compliant",
+			compliance: types.ComplianceResult{
+				LogGroupName:      "test-log-group",
+				Region:            "us-east-1",
+				MissingEncryption: false,
+				MissingRetention:  false,
+			},
+			expected: &types.RemediationResult{
+				LogGroupName:      "test-log-group",
+				Region:            "us-east-1",
+				EncryptionApplied: false,
+				RetentionApplied:  false,
+				Success:           true,
+				Error:             nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := dryRunService.RemediateLogGroup(ctx, tt.compliance)
+
+			assert.NoError(t, err)
+			assert.Equal(t, *tt.expected, *result)
+		})
+	}
+}
+
+func TestDryRunComplianceService_ProcessNonCompliantResourcesOptimized(t *testing.T) {
+	ctx := context.Background()
+	dryRunService := NewDryRunComplianceService(nil) // Don't need real service for dry-run
+
+	request := types.BatchComplianceRequest{
+		ConfigRuleName: "test-rule",
+		Region:         "us-east-1",
+		BatchSize:      10,
+		NonCompliantResults: []types.NonCompliantResource{
+			{
+				ResourceId:   "log-group-1",
+				ResourceName: "log-group-1",
+				ResourceType: "AWS::Logs::LogGroup",
+				Region:       "us-east-1",
+				Annotation:   "Missing encryption",
+			},
+			{
+				ResourceId:   "log-group-2",
+				ResourceName: "log-group-2",
+				ResourceType: "AWS::Logs::LogGroup",
+				Region:       "us-east-1",
+				Annotation:   "Missing retention",
+			},
+			{
+				ResourceId:   "log-group-3",
+				ResourceName: "log-group-3",
+				ResourceType: "AWS::Logs::LogGroup",
+				Region:       "us-east-1",
+				Annotation:   "",
+			},
+		},
+	}
+
+	result, err := dryRunService.ProcessNonCompliantResourcesOptimized(ctx, request)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 3, result.TotalProcessed)
+	assert.Equal(t, 3, result.SuccessCount)
+	assert.Equal(t, 0, result.FailureCount)
+	assert.Len(t, result.Results, 3)
+
+	// Check individual results
+	for i, r := range result.Results {
+		assert.Equal(t, request.NonCompliantResults[i].ResourceName, r.LogGroupName)
+		assert.Equal(t, request.NonCompliantResults[i].Region, r.Region)
+		assert.True(t, r.Success)
+		assert.Nil(t, r.Error)
+
+		// Resources with annotations should have remediation flags set
+		if request.NonCompliantResults[i].Annotation != "" {
+			assert.True(t, r.EncryptionApplied || r.RetentionApplied)
+		}
+	}
+}

--- a/internal/container/processor.go
+++ b/internal/container/processor.go
@@ -1,0 +1,356 @@
+package container
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/zsoftly/logguardian/internal/handler"
+	"github.com/zsoftly/logguardian/internal/service"
+	"github.com/zsoftly/logguardian/internal/types"
+)
+
+type CommandProcessor struct {
+	handler      *handler.ComplianceHandler
+	service      service.ComplianceServiceInterface
+	options      ProcessorOptions
+	executionLog []ExecutionLogEntry
+}
+
+type ProcessorOptions struct {
+	DryRun       bool
+	ExecutionID  string
+	OutputFormat string
+}
+
+type CommandRequest struct {
+	Type           string
+	ConfigRuleName string
+	Region         string
+	BatchSize      int
+}
+
+type ExecutionResult struct {
+	ExecutionID    string              `json:"execution_id"`
+	Status         string              `json:"status"`
+	Mode           string              `json:"mode"`
+	ConfigRuleName string              `json:"config_rule_name"`
+	Region         string              `json:"region"`
+	TotalProcessed int                 `json:"total_processed"`
+	SuccessCount   int                 `json:"success_count"`
+	FailureCount   int                 `json:"failure_count"`
+	Duration       string              `json:"duration"`
+	Timestamp      time.Time           `json:"timestamp"`
+	Resources      []ResourceResult    `json:"resources,omitempty"`
+	DryRunSummary  *DryRunSummary      `json:"dry_run_summary,omitempty"`
+	Error          string              `json:"error,omitempty"`
+	ExecutionLog   []ExecutionLogEntry `json:"execution_log,omitempty"`
+}
+
+type ResourceResult struct {
+	ResourceID        string    `json:"resource_id"`
+	ResourceName      string    `json:"resource_name"`
+	Status            string    `json:"status"`
+	EncryptionApplied bool      `json:"encryption_applied"`
+	RetentionApplied  bool      `json:"retention_applied"`
+	Error             string    `json:"error,omitempty"`
+	Timestamp         time.Time `json:"timestamp"`
+}
+
+type DryRunSummary struct {
+	WouldApplyEncryption int `json:"would_apply_encryption"`
+	WouldApplyRetention  int `json:"would_apply_retention"`
+	AlreadyCompliant     int `json:"already_compliant"`
+	TotalResources       int `json:"total_resources"`
+}
+
+type ExecutionLogEntry struct {
+	Timestamp time.Time `json:"timestamp"`
+	Level     string    `json:"level"`
+	Message   string    `json:"message"`
+	Details   any       `json:"details,omitempty"`
+}
+
+func NewCommandProcessor(awsCfg aws.Config, options ProcessorOptions) *CommandProcessor {
+	var complianceService service.ComplianceServiceInterface
+
+	if options.DryRun {
+		// Create a dry-run wrapper for the compliance service
+		realService := service.NewComplianceService(awsCfg)
+		complianceService = NewDryRunComplianceService(realService)
+	} else {
+		complianceService = service.NewComplianceService(awsCfg)
+	}
+
+	h := handler.NewComplianceHandler(complianceService)
+
+	return &CommandProcessor{
+		handler:      h,
+		service:      complianceService,
+		options:      options,
+		executionLog: []ExecutionLogEntry{},
+	}
+}
+
+func (p *CommandProcessor) Execute(ctx context.Context, request CommandRequest) (*ExecutionResult, error) {
+	startTime := time.Now()
+
+	p.logEntry("INFO", "Starting command execution", map[string]any{
+		"type":        request.Type,
+		"config_rule": request.ConfigRuleName,
+		"region":      request.Region,
+		"batch_size":  request.BatchSize,
+		"dry_run":     p.options.DryRun,
+	})
+
+	result := &ExecutionResult{
+		ExecutionID:    p.options.ExecutionID,
+		Status:         "running",
+		Mode:           p.getMode(),
+		ConfigRuleName: request.ConfigRuleName,
+		Region:         request.Region,
+		Timestamp:      startTime,
+		Resources:      []ResourceResult{},
+	}
+
+	switch request.Type {
+	case "config-rule-evaluation":
+		err := p.processConfigRuleEvaluation(ctx, request, result)
+		if err != nil {
+			result.Status = "failed"
+			result.Error = err.Error()
+			p.logEntry("ERROR", "Execution failed", map[string]any{"error": err.Error()})
+			return result, err
+		}
+	default:
+		err := fmt.Errorf("unsupported request type: %s", request.Type)
+		result.Status = "failed"
+		result.Error = err.Error()
+		return result, err
+	}
+
+	result.Status = "completed"
+	result.Duration = time.Since(startTime).String()
+	result.ExecutionLog = p.executionLog
+
+	p.logEntry("INFO", "Command execution completed", map[string]any{
+		"duration":        result.Duration,
+		"total_processed": result.TotalProcessed,
+		"success_count":   result.SuccessCount,
+		"failure_count":   result.FailureCount,
+	})
+
+	return result, nil
+}
+
+func (p *CommandProcessor) processConfigRuleEvaluation(ctx context.Context, request CommandRequest, result *ExecutionResult) error {
+	// Step 1: Get non-compliant resources
+	p.logEntry("INFO", "Retrieving non-compliant resources", map[string]any{
+		"config_rule": request.ConfigRuleName,
+		"region":      request.Region,
+	})
+
+	nonCompliantResources, err := p.service.GetNonCompliantResources(ctx, request.ConfigRuleName, request.Region)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve non-compliant resources: %w", err)
+	}
+
+	if len(nonCompliantResources) == 0 {
+		p.logEntry("INFO", "No non-compliant resources found", nil)
+		result.TotalProcessed = 0
+		return nil
+	}
+
+	p.logEntry("INFO", "Found non-compliant resources", map[string]any{
+		"count": len(nonCompliantResources),
+	})
+
+	// Step 2: Validate resource existence
+	validResources, err := p.service.ValidateResourceExistence(ctx, nonCompliantResources)
+	if err != nil {
+		return fmt.Errorf("failed to validate resource existence: %w", err)
+	}
+
+	if len(validResources) == 0 {
+		p.logEntry("INFO", "No valid resources found after validation", nil)
+		result.TotalProcessed = 0
+		return nil
+	}
+
+	p.logEntry("INFO", "Validated resources for processing", map[string]any{
+		"valid_count":    len(validResources),
+		"filtered_count": len(nonCompliantResources) - len(validResources),
+	})
+
+	// Step 3: Process resources
+	if p.options.DryRun {
+		return p.processDryRun(ctx, request, validResources, result)
+	} else {
+		return p.processResources(ctx, request, validResources, result)
+	}
+}
+
+func (p *CommandProcessor) processResources(ctx context.Context, request CommandRequest, resources []types.NonCompliantResource, result *ExecutionResult) error {
+	batchRequest := types.BatchComplianceRequest{
+		ConfigRuleName:      request.ConfigRuleName,
+		NonCompliantResults: resources,
+		Region:              request.Region,
+		BatchSize:           request.BatchSize,
+	}
+
+	batchResult, err := p.service.ProcessNonCompliantResourcesOptimized(ctx, batchRequest)
+	if err != nil {
+		return fmt.Errorf("batch processing failed: %w", err)
+	}
+
+	result.TotalProcessed = batchResult.TotalProcessed
+	result.SuccessCount = batchResult.SuccessCount
+	result.FailureCount = batchResult.FailureCount
+
+	// Convert batch results to resource results
+	for _, r := range batchResult.Results {
+		resourceResult := ResourceResult{
+			ResourceID:        r.LogGroupName,
+			ResourceName:      r.LogGroupName,
+			Status:            getResourceStatus(r),
+			EncryptionApplied: r.EncryptionApplied,
+			RetentionApplied:  r.RetentionApplied,
+			Timestamp:         time.Now(),
+		}
+		if r.Error != nil {
+			resourceResult.Error = r.Error.Error()
+		}
+		result.Resources = append(result.Resources, resourceResult)
+	}
+
+	return nil
+}
+
+func (p *CommandProcessor) processDryRun(ctx context.Context, request CommandRequest, resources []types.NonCompliantResource, result *ExecutionResult) error {
+	dryRunSummary := &DryRunSummary{
+		TotalResources: len(resources),
+	}
+
+	p.logEntry("INFO", "Running in dry-run mode", map[string]any{
+		"total_resources": len(resources),
+	})
+
+	// Analyze each resource to determine what would be done
+	ruleClassifier := types.NewRuleClassifier()
+	ruleType := ruleClassifier.ClassifyRule(request.ConfigRuleName)
+
+	for _, resource := range resources {
+		// Get current state
+		compliance, err := p.analyzeResourceCompliance(ctx, resource, ruleType)
+		if err != nil {
+			p.logEntry("WARN", "Failed to analyze resource", map[string]any{
+				"resource": resource.ResourceName,
+				"error":    err.Error(),
+			})
+			result.FailureCount++
+			continue
+		}
+
+		resourceResult := ResourceResult{
+			ResourceID:   resource.ResourceId,
+			ResourceName: resource.ResourceName,
+			Status:       "dry-run",
+			Timestamp:    time.Now(),
+		}
+
+		if compliance.MissingEncryption {
+			dryRunSummary.WouldApplyEncryption++
+			resourceResult.EncryptionApplied = true
+			p.logEntry("INFO", "Would apply encryption", map[string]any{
+				"resource": resource.ResourceName,
+			})
+		}
+
+		if compliance.MissingRetention {
+			dryRunSummary.WouldApplyRetention++
+			resourceResult.RetentionApplied = true
+			p.logEntry("INFO", "Would apply retention", map[string]any{
+				"resource": resource.ResourceName,
+			})
+		}
+
+		if !compliance.MissingEncryption && !compliance.MissingRetention {
+			dryRunSummary.AlreadyCompliant++
+			resourceResult.Status = "compliant"
+			p.logEntry("INFO", "Resource already compliant", map[string]any{
+				"resource": resource.ResourceName,
+			})
+		}
+
+		result.Resources = append(result.Resources, resourceResult)
+		result.SuccessCount++
+	}
+
+	result.TotalProcessed = len(resources)
+	result.DryRunSummary = dryRunSummary
+
+	return nil
+}
+
+func (p *CommandProcessor) analyzeResourceCompliance(ctx context.Context, resource types.NonCompliantResource, ruleType types.RuleType) (types.ComplianceResult, error) {
+	// This would need to fetch the actual log group configuration
+	// For now, we'll return based on the rule type
+	result := types.ComplianceResult{
+		LogGroupName: resource.ResourceName,
+		Region:       resource.Region,
+		AccountId:    resource.AccountId,
+	}
+
+	switch ruleType {
+	case types.RuleTypeEncryption:
+		result.MissingEncryption = true
+		result.MissingRetention = false
+	case types.RuleTypeRetention:
+		result.MissingRetention = true
+		result.MissingEncryption = false
+	default:
+		// Unknown rule type
+		result.MissingEncryption = false
+		result.MissingRetention = false
+	}
+
+	return result, nil
+}
+
+func (p *CommandProcessor) logEntry(level, message string, details any) {
+	entry := ExecutionLogEntry{
+		Timestamp: time.Now(),
+		Level:     level,
+		Message:   message,
+		Details:   details,
+	}
+	p.executionLog = append(p.executionLog, entry)
+
+	// Also log to slog
+	switch level {
+	case "ERROR":
+		slog.Error(message, "details", details)
+	case "WARN":
+		slog.Warn(message, "details", details)
+	case "INFO":
+		slog.Info(message, "details", details)
+	case "DEBUG":
+		slog.Debug(message, "details", details)
+	}
+}
+
+func (p *CommandProcessor) getMode() string {
+	if p.options.DryRun {
+		return "dry-run"
+	}
+	return "apply"
+}
+
+func getResourceStatus(result types.RemediationResult) string {
+	if result.Success {
+		return "success"
+	}
+	return "failed"
+}

--- a/internal/container/processor_test.go
+++ b/internal/container/processor_test.go
@@ -1,0 +1,311 @@
+package container
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/zsoftly/logguardian/internal/types"
+)
+
+// MockComplianceService is a mock implementation of ComplianceServiceInterface
+type MockComplianceService struct {
+	mock.Mock
+}
+
+func (m *MockComplianceService) GetNonCompliantResources(ctx context.Context, configRuleName, region string) ([]types.NonCompliantResource, error) {
+	args := m.Called(ctx, configRuleName, region)
+	return args.Get(0).([]types.NonCompliantResource), args.Error(1)
+}
+
+func (m *MockComplianceService) ValidateResourceExistence(ctx context.Context, resources []types.NonCompliantResource) ([]types.NonCompliantResource, error) {
+	args := m.Called(ctx, resources)
+	return args.Get(0).([]types.NonCompliantResource), args.Error(1)
+}
+
+func (m *MockComplianceService) RemediateLogGroup(ctx context.Context, compliance types.ComplianceResult) (*types.RemediationResult, error) {
+	args := m.Called(ctx, compliance)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*types.RemediationResult), args.Error(1)
+}
+
+func (m *MockComplianceService) ProcessNonCompliantResourcesOptimized(ctx context.Context, request types.BatchComplianceRequest) (*types.BatchRemediationResult, error) {
+	args := m.Called(ctx, request)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*types.BatchRemediationResult), args.Error(1)
+}
+
+func (m *MockComplianceService) EvaluateCompliance(ctx context.Context, logGroupName, region string) (types.ComplianceResult, error) {
+	args := m.Called(ctx, logGroupName, region)
+	return args.Get(0).(types.ComplianceResult), args.Error(1)
+}
+
+func TestNewCommandProcessor(t *testing.T) {
+	tests := []struct {
+		name    string
+		options ProcessorOptions
+	}{
+		{
+			name: "regular mode",
+			options: ProcessorOptions{
+				DryRun:       false,
+				ExecutionID:  "test-123",
+				OutputFormat: "json",
+			},
+		},
+		{
+			name: "dry-run mode",
+			options: ProcessorOptions{
+				DryRun:       true,
+				ExecutionID:  "test-456",
+				OutputFormat: "text",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := aws.Config{}
+			processor := NewCommandProcessor(cfg, tt.options)
+
+			assert.NotNil(t, processor)
+			assert.NotNil(t, processor.handler)
+			assert.NotNil(t, processor.service)
+			assert.Equal(t, tt.options.ExecutionID, processor.options.ExecutionID)
+			assert.Equal(t, tt.options.DryRun, processor.options.DryRun)
+		})
+	}
+}
+
+func TestCommandProcessor_Execute(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name           string
+		request        CommandRequest
+		options        ProcessorOptions
+		mockSetup      func(*MockComplianceService)
+		expectedStatus string
+		expectedError  bool
+	}{
+		{
+			name: "successful execution",
+			request: CommandRequest{
+				Type:           "config-rule-evaluation",
+				ConfigRuleName: "test-rule",
+				Region:         "us-east-1",
+				BatchSize:      10,
+			},
+			options: ProcessorOptions{
+				DryRun:       false,
+				ExecutionID:  "test-123",
+				OutputFormat: "json",
+			},
+			mockSetup: func(m *MockComplianceService) {
+				// Mock GetNonCompliantResources
+				nonCompliant := []types.NonCompliantResource{
+					{
+						ResourceId:   "log-group-1",
+						ResourceName: "log-group-1",
+						ResourceType: "AWS::Logs::LogGroup",
+						Region:       "us-east-1",
+					},
+				}
+				m.On("GetNonCompliantResources", ctx, "test-rule", "us-east-1").
+					Return(nonCompliant, nil)
+
+				// Mock ValidateResourceExistence
+				m.On("ValidateResourceExistence", ctx, nonCompliant).
+					Return(nonCompliant, nil)
+
+				// Mock ProcessNonCompliantResourcesOptimized
+				batchRequest := types.BatchComplianceRequest{
+					ConfigRuleName:      "test-rule",
+					NonCompliantResults: nonCompliant,
+					Region:              "us-east-1",
+					BatchSize:           10,
+				}
+				batchResult := &types.BatchRemediationResult{
+					TotalProcessed: 1,
+					SuccessCount:   1,
+					FailureCount:   0,
+					Results: []types.RemediationResult{
+						{
+							LogGroupName:      "log-group-1",
+							Region:            "us-east-1",
+							EncryptionApplied: true,
+							Success:           true,
+						},
+					},
+				}
+				m.On("ProcessNonCompliantResourcesOptimized", ctx, batchRequest).
+					Return(batchResult, nil)
+			},
+			expectedStatus: "completed",
+			expectedError:  false,
+		},
+		{
+			name: "no non-compliant resources",
+			request: CommandRequest{
+				Type:           "config-rule-evaluation",
+				ConfigRuleName: "test-rule",
+				Region:         "us-east-1",
+				BatchSize:      10,
+			},
+			options: ProcessorOptions{
+				DryRun:       false,
+				ExecutionID:  "test-456",
+				OutputFormat: "json",
+			},
+			mockSetup: func(m *MockComplianceService) {
+				// Mock GetNonCompliantResources returning empty
+				m.On("GetNonCompliantResources", ctx, "test-rule", "us-east-1").
+					Return([]types.NonCompliantResource{}, nil)
+			},
+			expectedStatus: "completed",
+			expectedError:  false,
+		},
+		{
+			name: "unsupported request type",
+			request: CommandRequest{
+				Type: "unsupported-type",
+			},
+			options: ProcessorOptions{
+				DryRun:       false,
+				ExecutionID:  "test-789",
+				OutputFormat: "json",
+			},
+			mockSetup:      func(m *MockComplianceService) {},
+			expectedStatus: "failed",
+			expectedError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockService := new(MockComplianceService)
+			tt.mockSetup(mockService)
+
+			// Create processor with mock service
+			processor := &CommandProcessor{
+				service:      mockService,
+				options:      tt.options,
+				executionLog: []ExecutionLogEntry{},
+			}
+
+			// Need to create handler manually since we're using mock
+			cfg := aws.Config{}
+			realProcessor := NewCommandProcessor(cfg, tt.options)
+			processor.handler = realProcessor.handler
+
+			result, err := processor.Execute(ctx, tt.request)
+
+			if tt.expectedError {
+				assert.Error(t, err)
+				assert.NotNil(t, result)
+				assert.Equal(t, tt.expectedStatus, result.Status)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+				assert.Equal(t, tt.expectedStatus, result.Status)
+				assert.Equal(t, tt.options.ExecutionID, result.ExecutionID)
+			}
+
+			mockService.AssertExpectations(t)
+		})
+	}
+}
+
+func TestCommandProcessor_GetMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		dryRun   bool
+		expected string
+	}{
+		{
+			name:     "dry-run mode",
+			dryRun:   true,
+			expected: "dry-run",
+		},
+		{
+			name:     "apply mode",
+			dryRun:   false,
+			expected: "apply",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			processor := &CommandProcessor{
+				options: ProcessorOptions{
+					DryRun: tt.dryRun,
+				},
+			}
+			assert.Equal(t, tt.expected, processor.getMode())
+		})
+	}
+}
+
+func TestGetResourceStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		result   types.RemediationResult
+		expected string
+	}{
+		{
+			name: "successful result",
+			result: types.RemediationResult{
+				Success: true,
+			},
+			expected: "success",
+		},
+		{
+			name: "failed result",
+			result: types.RemediationResult{
+				Success: false,
+			},
+			expected: "failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, getResourceStatus(tt.result))
+		})
+	}
+}
+
+func TestCommandProcessor_LogEntry(t *testing.T) {
+	processor := &CommandProcessor{
+		executionLog: []ExecutionLogEntry{},
+	}
+
+	testCases := []struct {
+		level   string
+		message string
+		details any
+	}{
+		{"INFO", "Test info message", map[string]any{"key": "value"}},
+		{"WARN", "Test warning", nil},
+		{"ERROR", "Test error", "error details"},
+		{"DEBUG", "Test debug", 123},
+	}
+
+	for i, tc := range testCases {
+		processor.logEntry(tc.level, tc.message, tc.details)
+
+		assert.Len(t, processor.executionLog, i+1)
+		entry := processor.executionLog[i]
+		assert.Equal(t, tc.level, entry.Level)
+		assert.Equal(t, tc.message, entry.Message)
+		assert.Equal(t, tc.details, entry.Details)
+		assert.WithinDuration(t, time.Now(), entry.Timestamp, time.Second)
+	}
+}


### PR DESCRIPTION
## Description
- Implemented DryRunComplianceService to simulate compliance checks without making changes.
- Added tests for DryRunComplianceService covering various scenarios.
- Created CommandProcessor to handle command execution with dry-run options.
- Developed tests for CommandProcessor, including execution flow and logging.
- Introduced mock service for testing compliance service interactions.
- Added unit tests for authentication strategies to ensure correct priority and availability checks.

## Checklist
- [ ] Tests pass
- [ ] Documentation updated
- [ ] Breaking changes noted

## Testing
How was this tested?